### PR TITLE
chore(docker): move and rename bind mounts for app directories

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ${MYCQU_SERVICE_EXPOSE_PORT}
     restart: always
     volumes:
-      - ${MYCQU_SERVICE_HOME_DIR}/config:/src/utils/config
+      - ${MYCQU_SERVICE_HOME_DIR}/logs:/app/logs
+      - ${MYCQU_SERVICE_HOME_DIR}/config:/app/config
       - ${_321CQU_PUBLIC_REPOSITORY_PATH}/python_package:/_321CQU_package
     environment:
       PYTHONPATH: /_321CQU_package


### PR DESCRIPTION
Update docker-compose volumes to mount host paths into the container locations that match the application's expected layout. Replace the old config mount path mapping and add a dedicated logs mount.

- mount host logs directory to /app/logs instead of mounting config to /src/utils/config
- move config mount to /app/config to centralize app resources
- keep package mount unchanged; set PYTHONPATH via environment as before

This aligns container paths with the application's runtime structure and ensures logs persist on the host.