### PR TITLE
feat: Prometheus 抓取 api-gateway 指标增加 Bearer Token 验证

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
     restart: always
     volumes:
       - ${_321CQU_PUBLIC_REPOSITORY_PATH}/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ${_321CQU_PUBLIC_REPOSITORY_PATH}/prometheus/token:/etc/prometheus/token:ro
       - prometheus-data:/prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -5,6 +5,7 @@ global:
 scrape_configs:
   - job_name: api-gateway
     metrics_path: /metrics
+    bearer_token_file: /etc/prometheus/token
     static_configs:
       - targets:
           - api-gateway:8000


### PR DESCRIPTION
- prometheus.yml 新增 bearer_token_file 配置，从挂载文件读取 token
- docker-compose.yml 增加 token 文件挂载（/etc/prometheus/token）

部署时需在目标服务器 ${_321CQU_PUBLIC_REPOSITORY_PATH}/prometheus/token 中写入 Bearer token。